### PR TITLE
Fix support for :json format

### DIFF
--- a/app/controllers/devise/magic_links_controller.rb
+++ b/app/controllers/devise/magic_links_controller.rb
@@ -16,7 +16,7 @@ class Devise::MagicLinksController < DeviseController
     yield resource if block_given?
 
     if successfully_sent?(resource)
-      if resource.magic_link_confirmation_page?
+      if is_navigational_format? && resource.magic_link_confirmation_page?
         flash.delete(:notice)
         respond_with_navigational(resource) { render :confirm }
       else


### PR DESCRIPTION
For some reason, if you call respond_with (or respond_with_navigational)
and don't pass a `location`, you will get an error and a 500, even
though the non-navigational formats don't even use `location`. This
commit makes sure to always include the location if
`!is_navigational_format?`.

I tried this with `paranoid` on and off